### PR TITLE
include needed header <QStyle> (using Qt 5.11.1)

### DIFF
--- a/Editor/editing/_scenes/level/itemmsgbox.cpp
+++ b/Editor/editing/_scenes/level/itemmsgbox.cpp
@@ -19,6 +19,7 @@
 #include <QFontDatabase>
 #include <QFontMetrics>
 #include <QScrollBar>
+#include <QStyle>
 
 #include "itemmsgbox.h"
 #include <ui_itemmsgbox.h>


### PR DESCRIPTION
fixes a build error